### PR TITLE
Add additional filters on content state and ignore comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,17 @@ The `${{ secrets.GITHUB_TOKEN }}` token can be used only when all project column
 2. `repo` to access information in private repositories
 3. `user` to access information in user repositories (if needed)
 
-### Filtering cards mirroring
+### Filtering mirrored cards
+
+##### Manual filtering
+
+`<!-- mirror ignore -->`
+
+Filters cards based on the existence of a mirror ignore comment in the card content.  The comment can be added to card notes, or to linked issue or PR bodies.
+
+When added to cards in the source project column, the cards will be ignored and not added to the target column.  When added to cards in the target project column, the cards will be ignored and will not be removed from the target column.
+
+##### Filtering on action inputs
 
 Cards can be filtered from mirroring by specifying additional inputs on the action workflow.
 
@@ -71,3 +81,9 @@ Label filters use exact, case sensitive comparisons to determine whether to mirr
 Filters mirrored cards based on the displayed card content.  Issue/PR titles is evaluated when they are linked as cards, otherwise the card's note text is used.
 
 Content filters use partial, case insensitive comparisons when determining which cards to mirror.  Content filter inputs can contain multiple filters separated by commas (`'first, second'`), and will be mirrored if any content matches are found (i.e. `OR` logic).  Content filters containing commas must be wrapped in quotes (`'first, second, "matching, with a comma"'`)
+
+**state_filter**
+
+Filters mirrored cards based on linked issue or PR state. Note cards do not have a state, and will never be filtered based on this input.  Must be one of:
+- `open`
+- `closed`

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   content_filter:
     description: "Filter to cards with matching note content or issue/PR title"
     required: false
+  state_filter:
+    description: "Filter to cards with matching issue or PR state, either 'open' or 'closed'"
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/filters.js
+++ b/src/filters.js
@@ -86,9 +86,29 @@ function filterByState(cards) {
     return true;
   });
 }
+
+const IGNORE_COMMENT = '<!-- mirror ignore -->';
+function filterIgnored(cards) {
+  return cards.filter(card => {
+    if (card.note) {
+      // don't include cards that have the ignore comment in the note
+      return !card.note.includes(IGNORE_COMMENT);
+    }
+
+    if (card.content && card.content.body) {
+      // don't include cards that have the ignore comment in content body
+      return !card.content.body.includes(IGNORE_COMMENT);
+    }
+
+    // do not filter cards that can't include ignored stamps
+    return true;
+  });
+}
+
 module.exports = {
   type: filterByType,
   content: filterByContent,
   label: filterByLabel,
   state: filterByState,
+  ignored: filterIgnored
 };

--- a/src/filters.js
+++ b/src/filters.js
@@ -69,8 +69,26 @@ function filterByLabel(cards) {
   });
 }
 
+function filterByState(cards) {
+  let stateFilter = core.getInput('state_filter', { required: false });
+  if (!stateFilter) {
+    return cards;
+  }
+
+  stateFilter = stateFilter.toUpperCase();
+  return cards.filter(card => {
+    if (card.content) {
+      // only include cards for issues and PRs in a matching state
+      return card.content.state === stateFilter;
+    }
+
+    // don't filter cards that can't be filtered by state
+    return true;
+  });
+}
 module.exports = {
   type: filterByType,
   content: filterByContent,
-  label: filterByLabel
+  label: filterByLabel,
+  state: filterByState,
 };

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -1,6 +1,7 @@
 const projectCardContentFields = `
 id
 title
+state
 labels(first: 20) {
   nodes {
     name

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -2,6 +2,7 @@ const projectCardContentFields = `
 id
 title
 state
+body
 labels(first: 20) {
   nodes {
     name

--- a/src/linked-project-columns.js
+++ b/src/linked-project-columns.js
@@ -89,7 +89,7 @@ async function run() {
     // target column based on the remaining filters
     const { sourceColumn, targetColumn } = response;
     const sourceCards = applyFilters(sourceColumn.cards.nodes, [...Object.values(filters)]);
-    const targetCards = targetColumn.cards.nodes;
+    const targetCards = applyFilters(targetColumn.cards.nodes, [filters.ignored]);
 
     // prepend the automation note card to the filtered source cards, so that
     // it will be created if needed in the target column.

--- a/test/linked-project-columns.test.js
+++ b/test/linked-project-columns.test.js
@@ -165,7 +165,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(2).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
   });
 
-  it('filters mirrored cards to note type', async () => {
+  it('filters source cards to note type', async () => {
     process.env.INPUT_TYPE_FILTER = 'note';
     getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, content: { id: 1000 } });
 
@@ -179,7 +179,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
   });
 
-  it('filters mirrored cards to content type', async () => {
+  it('filters source cards to content type', async () => {
     process.env.INPUT_TYPE_FILTER = 'content';
     getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, content: { id: 1000 } });
 
@@ -193,7 +193,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
   });
 
-  it('filters mirrored content cards based on labels', async () => {
+  it('filters source content cards based on labels', async () => {
     process.env.INPUT_LABEL_FILTER = 'label 2';
     getColumnsResponse.sourceColumn.cards.nodes.push(
       {
@@ -235,7 +235,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
   });
 
-  it('does not filter mirrored note cards based on labels', async () => {
+  it('does not filter source note cards based on labels', async () => {
     process.env.INPUT_LABEL_FILTER = '1, 2, other';
     getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' });
 
@@ -249,7 +249,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
   });
 
-  it('filters mirrored note cards based on note content', async () => {
+  it('filters source note cards based on note content', async () => {
     process.env.INPUT_CONTENT_FILTER = '1, note 2, other';
     getColumnsResponse.sourceColumn.cards.nodes.push(
       {
@@ -278,7 +278,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(5).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 202, afterCardId: 201 }]);
   });
 
-  it('filters mirrored content cards based on title content', async () => {
+  it('filters source content cards based on title content', async () => {
     process.env.INPUT_CONTENT_FILTER = '1, title 2, other';
     getColumnsResponse.sourceColumn.cards.nodes.push(
       {
@@ -316,7 +316,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(5).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 202, afterCardId: 201 }]);
   });
 
-  it('filters mirrored content cards based on state', async () => {
+  it('filters source content cards based on state', async () => {
     process.env.INPUT_STATE_FILTER = 'open';
     getColumnsResponse.sourceColumn.cards.nodes.push(
       {
@@ -345,7 +345,7 @@ describe('linked-project-columns', () => {
     expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
   });
 
-  it('does not filter mirrored note cards based on state', async () => {
+  it('does not filter source note cards based on state', async () => {
     process.env.INPUT_STATE_FILTER = 'open';
     getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: 'CLOSED' });
 
@@ -357,5 +357,59 @@ describe('linked-project-columns', () => {
     // call 1 -> add automation note
     expect(api.getCall(2).args).toEqual([queries.ADD_PROJECT_CARD, { columnId: 2, note: 'CLOSED' }]);
     expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
+  });
+
+  it('filters source content cards with ignore comments', async () => {
+    getColumnsResponse.sourceColumn.cards.nodes.push({
+      id: 1,
+      content: { id: 1001, body: 'test\n<!-- mirror ignore -->\ntest' }
+    });
+
+    await run();
+
+    expect(core.setFailed.callCount).toEqual(0);
+    expect(api.callCount).toEqual(2);
+    // call 0 -> get columns
+    // call 1 -> add automation note
+    // no call to add the ignored item from the source column
+  });
+
+  it('filters source note cards with ignore comments', async () => {
+    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: 'test\n<!-- mirror ignore -->\ntest' });
+
+    await run();
+
+    expect(core.setFailed.callCount).toEqual(0);
+    expect(api.callCount).toEqual(2);
+    // call 0 -> get columns
+    // call 1 -> add automation note
+    // no call to add the ignored item from the source column
+  });
+
+  it('filters target content cards with ignore comments', async () => {
+    getColumnsResponse.targetColumn.cards.nodes.push({
+      id: 1,
+      content: { id: 1001, body: 'test\n<!-- mirror ignore -->\ntest' }
+    });
+
+    await run();
+
+    expect(core.setFailed.callCount).toEqual(0);
+    expect(api.callCount).toEqual(2);
+    // call 0 -> get columns
+    // call 1 -> add automation note
+    // no call to delete the item from the target column
+  });
+
+  it('filters target note cards with ignore comments', async () => {
+    getColumnsResponse.targetColumn.cards.nodes.push({ id: 1, note: 'test\n<!-- mirror ignore -->\ntest' });
+
+    await run();
+
+    expect(core.setFailed.callCount).toEqual(0);
+    expect(api.callCount).toEqual(2);
+    // call 0 -> get columns
+    // call 1 -> add automation note
+    // no call to delete the item from the target column
   });
 });


### PR DESCRIPTION
closes https://github.com/jonabc/linked-project-columns/issues/7

Adds two more filters to limit what the running action affects in the target column.

1. Filtering by state - for cards that link to issues and PRs, filters based on the state of the linked content - `open` or `closed`

2. Filtering manually ignored cards - cards that include a `<!-- mirror ignore-->` comment will be ignored by the mirroring action.  The comment can be placed in a cards note, or in a linked issue/PR body.