### PR TITLE
Allow mirroring from multiple source columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 # GitHub Projects Column Mirror
 
-This is a GitHub Action to mirror columns in hierarchically modeled GitHub Projects.
+This GitHub Action mirrors columns between GitHub Projects boards.
 
-As an example, let's assume a scenario where there are issues used to document both epic and feature level scopes of work, where features belong to epics.
+## Use cases
 
-In this scenario, we have two project boards to individually track and give visibility into epics and features individually.  Each project board has the following columns:
+### Hierarchically modeled projects
+
+In this scenario there are issues used to document both epic and feature level scopes of work, where features belong to epics.  There are two project boards to individually track and give visibility into epics and features individually.  Each project board has the following columns:
 - backlog
 - active
 - done
@@ -17,9 +19,13 @@ If individual teams, or individual roles within a team, are only looking at the 
 
 This action makes this scenario easier by actively mirroring columns across project boards.  We can create an `active epics` column on the feature board that will automatically stay up to date with the `active` column on the epics project board.
 
+### Readonly views for projects
+
+In this scenario all cards, issues and PRs are managed on a primary project board. Users and teams create secondary boards for readonly views on specific content from the primary.
+
 ## Usage
 
-The action is intended to be run on a cron schedule, see [mirror.yml](./.github/workflows/mirror.yml) for an example.  The linked action workflow also uses the `push` event trigger for testing purposes only, and is not generally recommended for use.
+The action is intended to be run on a cron schedule, see [mirror.yml](./.github/workflows/mirror.yml) for an example.  The linked action workflow also uses the `push` event trigger for testing purposes only, which is for testing purposes only and not generally recommended for use.
 
 ```
 on:
@@ -35,6 +41,10 @@ jobs:
         target_column_id: <column node id>
         github_token: ${{ secrets.MIRROR_SECRET_PAT }} # can be secrets.GITHUB_TOKEN, see below
 ```
+
+### Multiple source columns
+
+The `source_column_id` input can contain multiple node column ids separated by commas (`'first, second'`).  Card ordering in the target column matches the ordering of the source column ids.  e.g. for `source_column_id: 'first, second'`, all cards from `first` will appear before cards from `second`.  
 
 ### Added notice card
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5078,19 +5078,19 @@ module.exports = resolveCommand;
 
 /***/ }),
 
-/***/ 503:
+/***/ 543:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 const core = __webpack_require__(470);
 
 // content filters are parsed from a string either as wrapped in quotes or comma separated
-const FILTER_LIST_REGEX = /\s*(?:((["'])([^\2]+?)\2)|([^"',]+))\s*/g;
-function getFilterList(input) {
+const INPUT_LIST_REGEX = /\s*(?:((["'])([^\2]+?)\2)|([^"',]+))\s*/g;
+function getInputList(input) {
   if (!input) {
     return [];
   }
 
-  return [...input.matchAll(FILTER_LIST_REGEX)]
+  return [...input.matchAll(INPUT_LIST_REGEX)]
     .map(match => match[3] || match[4])
     .map(filter => filter.trim())
     .filter(filter => !!filter);
@@ -5112,7 +5112,7 @@ function filterByType(cards) {
 }
 
 function filterByContent(cards) {
-  let contentFilters = getFilterList(core.getInput('content_filter', { required: false }));
+  let contentFilters = getInputList(core.getInput('content_filter', { required: false }));
   if (contentFilters.length === 0) {
     return cards;
   }
@@ -5136,7 +5136,7 @@ function filterByContent(cards) {
 }
 
 function filterByLabel(cards) {
-  const labelFilters = getFilterList(core.getInput('label_filter', { required: false }));
+  const labelFilters = getInputList(core.getInput('label_filter', { required: false }));
   if (labelFilters.length === 0) {
     return cards;
   }
@@ -5189,11 +5189,13 @@ function filterIgnored(cards) {
 }
 
 module.exports = {
-  type: filterByType,
-  content: filterByContent,
-  label: filterByLabel,
-  state: filterByState,
-  ignored: filterIgnored
+  filters: {
+    type: filterByType,
+    content: filterByContent,
+    label: filterByLabel,
+    state: filterByState,
+    ignored: filterIgnored
+  }
 };
 
 
@@ -5923,7 +5925,7 @@ module.exports = function (x) {
 const core = __webpack_require__(470);
 const octokit = __webpack_require__(898);
 const queries = __webpack_require__(63);
-const filters = __webpack_require__(503);
+const utils = __webpack_require__(543);
 
 const AUTOMATION_NOTE_TEMPLATE = `
 **DO NOT EDIT**
@@ -6016,8 +6018,8 @@ async function run() {
     // apply user supplied filters to cards from the source column and mirror the
     // target column based on the remaining filters
     const { sourceColumn, targetColumn } = response;
-    const sourceCards = applyFilters(sourceColumn.cards.nodes, [...Object.values(filters)]);
-    const targetCards = applyFilters(targetColumn.cards.nodes, [filters.ignored]);
+    const sourceCards = applyFilters(sourceColumn.cards.nodes, [...Object.values(utils.filters)]);
+    const targetCards = applyFilters(targetColumn.cards.nodes, [utils.filters.ignored]);
 
     // prepend the automation note card to the filtered source cards, so that
     // it will be created if needed in the target column.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1907,9 +1907,8 @@ name
 url
 project {
   name
-  url
 }
-cards(first: $cardLimit) {
+cards(first: 50) {
   nodes {
     ${projectCardFields}
   }
@@ -1917,8 +1916,8 @@ cards(first: $cardLimit) {
 `.trim();
 
 const GET_PROJECT_COLUMNS = `
-query($sourceColumnId: ID!, $targetColumnId: ID!, $cardLimit: Int!) {
-  sourceColumn: node(id: $sourceColumnId) {
+query($sourceColumnIds: [ID!]!, $targetColumnId: ID!) {
+  sourceColumns: nodes(ids: $sourceColumnIds) {
     ... on ProjectColumn {
       ${projectColumnFields}
     }
@@ -5189,6 +5188,7 @@ function filterIgnored(cards) {
 }
 
 module.exports = {
+  getInputList,
   filters: {
     type: filterByType,
     content: filterByContent,
@@ -5927,16 +5927,25 @@ const octokit = __webpack_require__(898);
 const queries = __webpack_require__(63);
 const utils = __webpack_require__(543);
 
-const AUTOMATION_NOTE_TEMPLATE = `
+const AUTOMATION_NOTE_HEADER = `
 **DO NOT EDIT**
-This column uses automation to mirror the ['<column name>' column](<column url>) from [<project name>](<project url>).
+This column is automatically populated from the following columns:
+`.trim();
+const AUTOMATION_NOTE_COLUMN_REFERENCE = `
+- [<project name>'s '<column name>' column](<column url>).
 `.trim();
 
-function getAutomationNote(column) {
-  return AUTOMATION_NOTE_TEMPLATE.replace('<column name>', column.name)
-    .replace('<column url>', column.url.replace('/columns/', '#column-'))
-    .replace('<project name>', column.project.name)
-    .replace('<project url>', column.project.url);
+function getAutomationNote(columns) {
+  const columnReferences = columns.map(column => {
+    return AUTOMATION_NOTE_COLUMN_REFERENCE.replace('<column name>', column.name)
+      .replace('<column url>', column.url.replace('/columns/', '#column-'))
+      .replace('<project name>', column.project.name);
+  });
+
+  return `
+${AUTOMATION_NOTE_HEADER}
+${columnReferences.join('\n')}
+`.trim();
 }
 
 // Find a card in an array of cards based on it's linked content, or it's note.
@@ -6006,26 +6015,27 @@ async function run() {
       }
     });
 
-    const sourceColumnId = core.getInput('source_column_id', { required: true });
+    const sourceColumnIds = utils.getInputList(core.getInput('source_column_id', { required: true }));
     const targetColumnId = core.getInput('target_column_id', { required: true });
 
     const response = await api(queries.GET_PROJECT_COLUMNS, {
-      sourceColumnId,
-      targetColumnId,
-      cardLimit: 100
+      sourceColumnIds,
+      targetColumnId
     });
 
     // apply user supplied filters to cards from the source column and mirror the
     // target column based on the remaining filters
-    const { sourceColumn, targetColumn } = response;
-    const sourceCards = applyFilters(sourceColumn.cards.nodes, [...Object.values(utils.filters)]);
+    const { sourceColumns, targetColumn } = response;
+    const sourceCards = sourceColumns.flatMap(column => {
+      return applyFilters(column.cards.nodes, [...Object.values(utils.filters)]);
+    });
     const targetCards = applyFilters(targetColumn.cards.nodes, [utils.filters.ignored]);
 
     // prepend the automation note card to the filtered source cards, so that
     // it will be created if needed in the target column.
     const addNoteInput = core.getInput('add_note');
     if (addNoteInput.toLowerCase() === 'true') {
-      sourceCards.unshift({ note: getAutomationNote(sourceColumn) });
+      sourceCards.unshift({ note: getAutomationNote(sourceColumns) });
     }
 
     // delete all cards in target column that do not exist in the source column,

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -29,9 +29,8 @@ name
 url
 project {
   name
-  url
 }
-cards(first: $cardLimit) {
+cards(first: 50) {
   nodes {
     ${projectCardFields}
   }
@@ -39,8 +38,8 @@ cards(first: $cardLimit) {
 `.trim();
 
 const GET_PROJECT_COLUMNS = `
-query($sourceColumnId: ID!, $targetColumnId: ID!, $cardLimit: Int!) {
-  sourceColumn: node(id: $sourceColumnId) {
+query($sourceColumnIds: [ID!]!, $targetColumnId: ID!) {
+  sourceColumns: nodes(ids: $sourceColumnIds) {
     ... on ProjectColumn {
       ${projectColumnFields}
     }

--- a/src/linked-project-columns.js
+++ b/src/linked-project-columns.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const octokit = require('@octokit/graphql');
 const queries = require('./graphql');
-const filters = require('./filters');
+const utils = require('./utils');
 
 const AUTOMATION_NOTE_TEMPLATE = `
 **DO NOT EDIT**
@@ -94,8 +94,8 @@ async function run() {
     // apply user supplied filters to cards from the source column and mirror the
     // target column based on the remaining filters
     const { sourceColumn, targetColumn } = response;
-    const sourceCards = applyFilters(sourceColumn.cards.nodes, [...Object.values(filters)]);
-    const targetCards = applyFilters(targetColumn.cards.nodes, [filters.ignored]);
+    const sourceCards = applyFilters(sourceColumn.cards.nodes, [...Object.values(utils.filters)]);
+    const targetCards = applyFilters(targetColumn.cards.nodes, [utils.filters.ignored]);
 
     // prepend the automation note card to the filtered source cards, so that
     // it will be created if needed in the target column.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,13 @@
 const core = require('@actions/core');
 
 // content filters are parsed from a string either as wrapped in quotes or comma separated
-const FILTER_LIST_REGEX = /\s*(?:((["'])([^\2]+?)\2)|([^"',]+))\s*/g;
-function getFilterList(input) {
+const INPUT_LIST_REGEX = /\s*(?:((["'])([^\2]+?)\2)|([^"',]+))\s*/g;
+function getInputList(input) {
   if (!input) {
     return [];
   }
 
-  return [...input.matchAll(FILTER_LIST_REGEX)]
+  return [...input.matchAll(INPUT_LIST_REGEX)]
     .map(match => match[3] || match[4])
     .map(filter => filter.trim())
     .filter(filter => !!filter);
@@ -29,7 +29,7 @@ function filterByType(cards) {
 }
 
 function filterByContent(cards) {
-  let contentFilters = getFilterList(core.getInput('content_filter', { required: false }));
+  let contentFilters = getInputList(core.getInput('content_filter', { required: false }));
   if (contentFilters.length === 0) {
     return cards;
   }
@@ -53,7 +53,7 @@ function filterByContent(cards) {
 }
 
 function filterByLabel(cards) {
-  const labelFilters = getFilterList(core.getInput('label_filter', { required: false }));
+  const labelFilters = getInputList(core.getInput('label_filter', { required: false }));
   if (labelFilters.length === 0) {
     return cards;
   }
@@ -106,9 +106,11 @@ function filterIgnored(cards) {
 }
 
 module.exports = {
-  type: filterByType,
-  content: filterByContent,
-  label: filterByLabel,
-  state: filterByState,
-  ignored: filterIgnored
+  filters: {
+    type: filterByType,
+    content: filterByContent,
+    label: filterByLabel,
+    state: filterByState,
+    ignored: filterIgnored
+  }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,6 +106,7 @@ function filterIgnored(cards) {
 }
 
 module.exports = {
+  getInputList,
   filters: {
     type: filterByType,
     content: filterByContent,

--- a/test/fixtures/get-project-columns.json
+++ b/test/fixtures/get-project-columns.json
@@ -1,23 +1,23 @@
 {
-  "sourceColumn": {
-    "id": 1,
-    "name": "source column",
-    "url": "https://example.com/projects/1/columns/1",
-    "project": {
-      "name": "source project",
-      "url": "https://example.com/projects/1"
-    },
-    "cards": {
-      "nodes": []
+  "sourceColumns": [
+    {
+      "id": 1,
+      "name": "source column",
+      "url": "https://example.com/projects/1/columns/1",
+      "project": {
+        "name": "source project"
+      },
+      "cards": {
+        "nodes": []
+      }
     }
-  },
+  ],
   "targetColumn": {
     "id": 2,
     "name": "target column",
     "url": "https://example.com/projects/2/columns/2",
     "project": {
-      "name": "target project",
-      "url": "https://example.com/projects/2"
+      "name": "target project"
     },
     "cards": {
       "nodes": []

--- a/test/linked-project-columns.test.js
+++ b/test/linked-project-columns.test.js
@@ -157,7 +157,7 @@ describe('linked-project-columns', () => {
   });
 
   it('adds cards from the source to the target', async () => {
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
 
     await run();
 
@@ -172,8 +172,48 @@ describe('linked-project-columns', () => {
     expect(api.getCall(5).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 202, afterCardId: 201 }]);
   });
 
+  it('adds cards from multiple sources to the target', async () => {
+    const secondSourceColumnId = 'second';
+    process.env.INPUT_SOURCE_COLUMN_ID = `${sourceColumnId},${secondSourceColumnId}`;
+
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
+    getColumnsResponse.sourceColumns.push({
+      id: 3,
+      name: 'second source column',
+      url: 'https://example.com/projects/1/columns/3',
+      project: {
+        name: 'source project'
+      },
+      cards: {
+        nodes: [
+          { id: 3, note: '3' },
+          { id: 4, note: '4' }
+        ]
+      }
+    });
+
+    await run();
+
+    expect(core.warning.callCount).toEqual(0);
+    expect(core.setFailed.callCount).toEqual(0);
+    expect(api.callCount).toEqual(10);
+    expect(api.getCall(0).args).toEqual([
+      queries.GET_PROJECT_COLUMNS,
+      { sourceColumnIds: [sourceColumnId, secondSourceColumnId], targetColumnId }
+    ]);
+    // call 1 -> add automation note
+    expect(api.getCall(2).args).toEqual([queries.ADD_PROJECT_CARD, { columnId: 2, note: '1' }]);
+    expect(api.getCall(3).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 201, afterCardId: 200 }]);
+    expect(api.getCall(4).args).toEqual([queries.ADD_PROJECT_CARD, { columnId: 2, note: '2' }]);
+    expect(api.getCall(5).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 202, afterCardId: 201 }]);
+    expect(api.getCall(6).args).toEqual([queries.ADD_PROJECT_CARD, { columnId: 2, note: '3' }]);
+    expect(api.getCall(7).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 203, afterCardId: 202 }]);
+    expect(api.getCall(8).args).toEqual([queries.ADD_PROJECT_CARD, { columnId: 2, note: '4' }]);
+    expect(api.getCall(9).args).toEqual([queries.MOVE_PROJECT_CARD, { columnId: 2, cardId: 204, afterCardId: 203 }]);
+  });
+
   it('logs a warning if a card cannot be added to the target', async () => {
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
     api
       .withArgs(queries.ADD_PROJECT_CARD)
       .onCall(1)
@@ -198,7 +238,7 @@ describe('linked-project-columns', () => {
   });
 
   it('moves cards on the target to match the source', async () => {
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
     getColumnsResponse.targetColumn.cards.nodes.push({ id: 202, note: '2' }, { id: 201, note: '1' });
 
     await run();
@@ -213,7 +253,7 @@ describe('linked-project-columns', () => {
 
   it('filters source cards to note type', async () => {
     process.env.INPUT_TYPE_FILTER = 'note';
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, content: { id: 1000 } });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, content: { id: 1000 } });
 
     await run();
 
@@ -228,7 +268,7 @@ describe('linked-project-columns', () => {
 
   it('filters source cards to content type', async () => {
     process.env.INPUT_TYPE_FILTER = 'content';
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' }, { id: 2, content: { id: 1000 } });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, content: { id: 1000 } });
 
     await run();
 
@@ -243,7 +283,7 @@ describe('linked-project-columns', () => {
 
   it('filters source content cards based on labels', async () => {
     process.env.INPUT_LABEL_FILTER = 'label 2';
-    getColumnsResponse.sourceColumn.cards.nodes.push(
+    getColumnsResponse.sourceColumns[0].cards.nodes.push(
       {
         id: 1,
         content: {
@@ -286,7 +326,7 @@ describe('linked-project-columns', () => {
 
   it('does not filter source note cards based on labels', async () => {
     process.env.INPUT_LABEL_FILTER = '1, 2, other';
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: '1' });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: '1' });
 
     await run();
 
@@ -301,7 +341,7 @@ describe('linked-project-columns', () => {
 
   it('filters source note cards based on note content', async () => {
     process.env.INPUT_CONTENT_FILTER = '1, note 2, other';
-    getColumnsResponse.sourceColumn.cards.nodes.push(
+    getColumnsResponse.sourceColumns[0].cards.nodes.push(
       {
         id: 1,
         note: 'note 1'
@@ -331,7 +371,7 @@ describe('linked-project-columns', () => {
 
   it('filters source content cards based on title content', async () => {
     process.env.INPUT_CONTENT_FILTER = '1, title 2, other';
-    getColumnsResponse.sourceColumn.cards.nodes.push(
+    getColumnsResponse.sourceColumns[0].cards.nodes.push(
       {
         id: 1,
         content: {
@@ -370,7 +410,7 @@ describe('linked-project-columns', () => {
 
   it('filters source content cards based on state', async () => {
     process.env.INPUT_STATE_FILTER = 'open';
-    getColumnsResponse.sourceColumn.cards.nodes.push(
+    getColumnsResponse.sourceColumns[0].cards.nodes.push(
       {
         id: 1,
         content: {
@@ -400,7 +440,7 @@ describe('linked-project-columns', () => {
 
   it('does not filter source note cards based on state', async () => {
     process.env.INPUT_STATE_FILTER = 'open';
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: 'CLOSED' });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: 'CLOSED' });
 
     await run();
 
@@ -414,7 +454,7 @@ describe('linked-project-columns', () => {
   });
 
   it('filters source content cards with ignore comments', async () => {
-    getColumnsResponse.sourceColumn.cards.nodes.push({
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({
       id: 1,
       content: { id: 1001, body: 'test\n<!-- mirror ignore -->\ntest' }
     });
@@ -430,7 +470,7 @@ describe('linked-project-columns', () => {
   });
 
   it('filters source note cards with ignore comments', async () => {
-    getColumnsResponse.sourceColumn.cards.nodes.push({ id: 1, note: 'test\n<!-- mirror ignore -->\ntest' });
+    getColumnsResponse.sourceColumns[0].cards.nodes.push({ id: 1, note: 'test\n<!-- mirror ignore -->\ntest' });
 
     await run();
 

--- a/test/linked-project-columns.test.js
+++ b/test/linked-project-columns.test.js
@@ -38,8 +38,8 @@ describe('linked-project-columns', () => {
       INPUT_ADD_NOTE: 'true'
     };
 
-    sinon.spy(core, 'setFailed');
-    sinon.spy(core, 'warning');
+    sinon.stub(core, 'setFailed');
+    sinon.stub(core, 'warning');
 
     api = sinon.stub();
     sinon.stub(octokit.graphql, 'defaults').returns(api);


### PR DESCRIPTION
closes https://github.com/jonabc/linked-project-columns/issues/12

From the readme update 

```
### Multiple source columns

The `source_column_id` input can contain multiple node column ids separated by commas (`'first, second'`).  Card ordering in the target column matches the ordering of the source column ids.  e.g. for `source_column_id: 'first, second'`, all cards from `first` will appear before cards from `second`.  
```

The explicit implementation changes here is pretty simple - gather cards from multiple sources and add them all to the array of source cards that are evaluated for mirroring.

Some aspects that are implicitly handled by the existing implementation:
1. filtering is applied to all source column cards
2. cards in the target column are ordered based on the order of the input column ids
3. pre-existing cards in the target column are matched against cards from all source columns
   - put another way, cards in the target column will only be removed if they are not found in any of the source columns
4. if a linked issue or PR appears in multiple source columns, a card is created in the target column only for the first reference

The other impact is that the format of the automation note is changed to a format that more easily scales to multiple source columns.

/cc @pgebheim 