### PR TITLE
Allow users to disable the automation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ jobs:
 
 ### Added notice card
 
-The action will add a notice to the top of the target project column, identifying the source project column and notifying users that the column is automatically managed.
+When the `add_note` action input is set to `'true'`, the action will add a notice to the top of the target project column, identifying the source project column and notifying users that the column is automatically managed.  Setting the `add_note` input to any other value will remove the note from the target column.
+
+To set a custom automation note, set `add_note: 'false'` and manually add a note to the target column that includes a [comment to ignore the card](#manual-filtering).
 
 ### Required permissions
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   state_filter:
     description: "Filter to cards with matching issue or PR state, either 'open' or 'closed'"
     required: false
+  add_note:
+    description: "Set to 'true' to automatically add an automation note to the target column"
+    required: false
+    default: 'true'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6021,7 +6021,10 @@ async function run() {
 
     // prepend the automation note card to the filtered source cards, so that
     // it will be created if needed in the target column.
-    sourceCards.unshift({ note: getAutomationNote(sourceColumn) });
+    const addNoteInput = core.getInput('add_note');
+    if (addNoteInput.toLowerCase() === 'true') {
+      sourceCards.unshift({ note: getAutomationNote(sourceColumn) });
+    }
 
     // delete all cards in target column that do not exist in the source column,
     // except for the automation note

--- a/src/linked-project-columns.js
+++ b/src/linked-project-columns.js
@@ -99,7 +99,10 @@ async function run() {
 
     // prepend the automation note card to the filtered source cards, so that
     // it will be created if needed in the target column.
-    sourceCards.unshift({ note: getAutomationNote(sourceColumn) });
+    const addNoteInput = core.getInput('add_note');
+    if (addNoteInput.toLowerCase() === 'true') {
+      sourceCards.unshift({ note: getAutomationNote(sourceColumn) });
+    }
 
     // delete all cards in target column that do not exist in the source column,
     // except for the automation note

--- a/test/linked-project-columns.test.js
+++ b/test/linked-project-columns.test.js
@@ -34,7 +34,8 @@ describe('linked-project-columns', () => {
       ...process.env,
       INPUT_GITHUB_TOKEN: token,
       INPUT_SOURCE_COLUMN_ID: sourceColumnId,
-      INPUT_TARGET_COLUMN_ID: targetColumnId
+      INPUT_TARGET_COLUMN_ID: targetColumnId,
+      INPUT_ADD_NOTE: 'true'
     };
 
     sinon.spy(core, 'setFailed');
@@ -127,6 +128,17 @@ describe('linked-project-columns', () => {
       columnId: 2,
       note: expect.stringMatching(/\*\*DO NOT EDIT\*\*/)
     });
+  });
+
+  it('does not add an automation note to the target column if the input is not true', async () => {
+    process.env.INPUT_ADD_NOTE = 'false';
+
+    await run();
+
+    expect(core.warning.callCount).toEqual(0);
+    expect(core.setFailed.callCount).toEqual(0);
+    // no call to add an automation note
+    expect(api.callCount).toEqual(1);
   });
 
   it('deletes cards from the target column that are not in source', async () => {


### PR DESCRIPTION
This adds an `add_note` input to allow users to disable the automatically generated note that gets added to the target column.

The automation notes tend to be bulky and can take up a lot of space in the target column.  This lets users remove the card entirely, or replace it with a custom note if they'd like by adding a card to the column and with a `<!-- mirror ignore -->` comment, which causes the action to ignore the card when considering which cards to remove from the target column.