### PR TITLE
Don't include archived project cards in query

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -30,7 +30,7 @@ url
 project {
   name
 }
-cards(first: 50) {
+cards(first: 50, archivedStates: [NOT_ARCHIVED]) {
   nodes {
     ${projectCardFields}
   }

--- a/test/linked-project-columns.test.js
+++ b/test/linked-project-columns.test.js
@@ -472,6 +472,17 @@ describe('linked-project-columns', () => {
     // no call to delete the item from the target column
   });
 
+  it('does not include archived cards', async () => {
+    await run();
+
+    expect(core.warning.callCount).toEqual(0);
+    expect(core.setFailed.callCount).toEqual(0);
+    expect(api.callCount).toEqual(2);
+    // call 0 -> get columns
+    // call 1 -> add automation note
+    expect(api.getCall(0).args[0]).toContain('archivedStates: [NOT_ARCHIVED]');
+  });
+
   describe('with multiple source columns', () => {
     const secondSourceColumnId = 'second';
 


### PR DESCRIPTION
Fixes https://github.com/jonabc/linked-project-columns/issues/17

Updates the GraphQL query to not include archived cards based on the [API documentation](https://developer.github.com/v4/object/projectcolumn/#connections) for the `archivedStates` argument.

This change should also cause the action to clean up any cards it erroneously created to match archived cards from the source columns.  Since these target cards won't be found to match to any cards on the source columns, which have been filtered out, they'll be automatically removed by default.

/cc @debrando FYI