### PR TITLE
Paginate cards from project columns

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1901,16 +1901,14 @@ content {
 }
 `.trim();
 
-// prettier-ignore
-const projectColumnFields = ({ after = false } = {}) => 
-`
+const projectColumnFields = `
 id
 name
 url
 project {
   name
 }
-cards(first: 50, archivedStates: [NOT_ARCHIVED]${after ? 'after: $after' : ''}) {
+cards(first: 50, archivedStates: [NOT_ARCHIVED], after: $after) {
   nodes {
     ${projectCardFields}
   }
@@ -1922,15 +1920,15 @@ cards(first: 50, archivedStates: [NOT_ARCHIVED]${after ? 'after: $after' : ''}) 
 `.trim();
 
 const GET_PROJECT_COLUMNS = `
-query($sourceColumnIds: [ID!]!, $targetColumnId: ID!) {
+query($sourceColumnIds: [ID!]!, $targetColumnId: ID!, $after: String) {
   sourceColumns: nodes(ids: $sourceColumnIds) {
     ... on ProjectColumn {
-      ${projectColumnFields()}
+      ${projectColumnFields}
     }
   }
   targetColumn: node(id: $targetColumnId) {
     ... on ProjectColumn {
-      ${projectColumnFields()}
+      ${projectColumnFields}
     }
   }
 }
@@ -1940,7 +1938,7 @@ const GET_SINGLE_PROJECT_COLUMN = `
 query($id: ID!, $after: String) {
   column: node(id: $id) {
     ... on ProjectColumn {
-      ${projectColumnFields({ after: true })}
+      ${projectColumnFields}
     }
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1901,16 +1901,22 @@ content {
 }
 `.trim();
 
-const projectColumnFields = `
+// prettier-ignore
+const projectColumnFields = ({ after = false } = {}) => 
+`
 id
 name
 url
 project {
   name
 }
-cards(first: 50, archivedStates: [NOT_ARCHIVED]) {
+cards(first: 50, archivedStates: [NOT_ARCHIVED]${after ? 'after: $after' : ''}) {
   nodes {
     ${projectCardFields}
+  }
+  pageInfo {
+    hasNextPage
+    endCursor
   }
 }
 `.trim();
@@ -1919,12 +1925,22 @@ const GET_PROJECT_COLUMNS = `
 query($sourceColumnIds: [ID!]!, $targetColumnId: ID!) {
   sourceColumns: nodes(ids: $sourceColumnIds) {
     ... on ProjectColumn {
-      ${projectColumnFields}
+      ${projectColumnFields()}
     }
   }
   targetColumn: node(id: $targetColumnId) {
     ... on ProjectColumn {
-      ${projectColumnFields}
+      ${projectColumnFields()}
+    }
+  }
+}
+`.trim();
+
+const GET_SINGLE_PROJECT_COLUMN = `
+query($id: ID!, $after: String) {
+  column: node(id: $id) {
+    ... on ProjectColumn {
+      ${projectColumnFields({ after: true })}
     }
   }
 }
@@ -1964,6 +1980,7 @@ mutation deleteProjectCard($cardId: ID!) {
 
 module.exports = {
   GET_PROJECT_COLUMNS,
+  GET_SINGLE_PROJECT_COLUMN,
   ADD_PROJECT_CARD,
   MOVE_PROJECT_CARD,
   DELETE_PROJECT_CARD
@@ -5948,6 +5965,29 @@ ${columnReferences.join('\n')}
 `.trim();
 }
 
+// Paginate project cards from all columns if/as needed
+async function paginateColumnCards(api, columns) {
+  for (let i = 0; i < columns.length; i += 1) {
+    const originalColumn = columns[i];
+
+    let currentColumn = originalColumn;
+    while (currentColumn.cards.pageInfo.hasNextPage) {
+      core.info(
+        `paginating ${currentColumn.project.name}:${currentColumn.name} after ${currentColumn.cards.pageInfo.endCursor}`
+      );
+
+      // eslint-disable-next-line no-await-in-loop
+      const { column } = await api(queries.GET_SINGLE_PROJECT_COLUMN, {
+        id: currentColumn.id,
+        after: currentColumn.cards.pageInfo.endCursor
+      });
+
+      originalColumn.cards.nodes.push(...column.cards.nodes);
+      currentColumn = column;
+    }
+  }
+}
+
 // Find a card in an array of cards based on it's linked content, or it's note.
 // Returns an array of [found card, index of found card]
 function findCard(card, cards) {
@@ -6018,14 +6058,16 @@ async function run() {
     const sourceColumnIds = utils.getInputList(core.getInput('source_column_id', { required: true }));
     const targetColumnId = core.getInput('target_column_id', { required: true });
 
-    const response = await api(queries.GET_PROJECT_COLUMNS, {
+    const { sourceColumns, targetColumn } = await api(queries.GET_PROJECT_COLUMNS, {
       sourceColumnIds,
       targetColumnId
     });
 
+    // paginate to gather all cards if needed
+    await paginateColumnCards(api, [...sourceColumns, targetColumn]);
+
     // apply user supplied filters to cards from the source column and mirror the
     // target column based on the remaining filters
-    const { sourceColumns, targetColumn } = response;
     const sourceCards = sourceColumns.flatMap(column => {
       return applyFilters(column.cards.nodes, [...Object.values(utils.filters)]);
     });

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -23,16 +23,14 @@ content {
 }
 `.trim();
 
-// prettier-ignore
-const projectColumnFields = ({ after = false } = {}) => 
-`
+const projectColumnFields = `
 id
 name
 url
 project {
   name
 }
-cards(first: 50, archivedStates: [NOT_ARCHIVED]${after ? 'after: $after' : ''}) {
+cards(first: 50, archivedStates: [NOT_ARCHIVED], after: $after) {
   nodes {
     ${projectCardFields}
   }
@@ -44,15 +42,15 @@ cards(first: 50, archivedStates: [NOT_ARCHIVED]${after ? 'after: $after' : ''}) 
 `.trim();
 
 const GET_PROJECT_COLUMNS = `
-query($sourceColumnIds: [ID!]!, $targetColumnId: ID!) {
+query($sourceColumnIds: [ID!]!, $targetColumnId: ID!, $after: String) {
   sourceColumns: nodes(ids: $sourceColumnIds) {
     ... on ProjectColumn {
-      ${projectColumnFields()}
+      ${projectColumnFields}
     }
   }
   targetColumn: node(id: $targetColumnId) {
     ... on ProjectColumn {
-      ${projectColumnFields()}
+      ${projectColumnFields}
     }
   }
 }
@@ -62,7 +60,7 @@ const GET_SINGLE_PROJECT_COLUMN = `
 query($id: ID!, $after: String) {
   column: node(id: $id) {
     ... on ProjectColumn {
-      ${projectColumnFields({ after: true })}
+      ${projectColumnFields}
     }
   }
 }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -23,16 +23,22 @@ content {
 }
 `.trim();
 
-const projectColumnFields = `
+// prettier-ignore
+const projectColumnFields = ({ after = false } = {}) => 
+`
 id
 name
 url
 project {
   name
 }
-cards(first: 50, archivedStates: [NOT_ARCHIVED]) {
+cards(first: 50, archivedStates: [NOT_ARCHIVED]${after ? 'after: $after' : ''}) {
   nodes {
     ${projectCardFields}
+  }
+  pageInfo {
+    hasNextPage
+    endCursor
   }
 }
 `.trim();
@@ -41,12 +47,22 @@ const GET_PROJECT_COLUMNS = `
 query($sourceColumnIds: [ID!]!, $targetColumnId: ID!) {
   sourceColumns: nodes(ids: $sourceColumnIds) {
     ... on ProjectColumn {
-      ${projectColumnFields}
+      ${projectColumnFields()}
     }
   }
   targetColumn: node(id: $targetColumnId) {
     ... on ProjectColumn {
-      ${projectColumnFields}
+      ${projectColumnFields()}
+    }
+  }
+}
+`.trim();
+
+const GET_SINGLE_PROJECT_COLUMN = `
+query($id: ID!, $after: String) {
+  column: node(id: $id) {
+    ... on ProjectColumn {
+      ${projectColumnFields({ after: true })}
     }
   }
 }
@@ -86,6 +102,7 @@ mutation deleteProjectCard($cardId: ID!) {
 
 module.exports = {
   GET_PROJECT_COLUMNS,
+  GET_SINGLE_PROJECT_COLUMN,
   ADD_PROJECT_CARD,
   MOVE_PROJECT_CARD,
   DELETE_PROJECT_CARD

--- a/src/linked-project-columns.js
+++ b/src/linked-project-columns.js
@@ -24,6 +24,29 @@ ${columnReferences.join('\n')}
 `.trim();
 }
 
+// Paginate project cards from all columns if/as needed
+async function paginateColumnCards(api, columns) {
+  for (let i = 0; i < columns.length; i += 1) {
+    const originalColumn = columns[i];
+
+    let currentColumn = originalColumn;
+    while (currentColumn.cards.pageInfo.hasNextPage) {
+      core.info(
+        `paginating ${currentColumn.project.name}:${currentColumn.name} after ${currentColumn.cards.pageInfo.endCursor}`
+      );
+
+      // eslint-disable-next-line no-await-in-loop
+      const { column } = await api(queries.GET_SINGLE_PROJECT_COLUMN, {
+        id: currentColumn.id,
+        after: currentColumn.cards.pageInfo.endCursor
+      });
+
+      originalColumn.cards.nodes.push(...column.cards.nodes);
+      currentColumn = column;
+    }
+  }
+}
+
 // Find a card in an array of cards based on it's linked content, or it's note.
 // Returns an array of [found card, index of found card]
 function findCard(card, cards) {
@@ -94,14 +117,16 @@ async function run() {
     const sourceColumnIds = utils.getInputList(core.getInput('source_column_id', { required: true }));
     const targetColumnId = core.getInput('target_column_id', { required: true });
 
-    const response = await api(queries.GET_PROJECT_COLUMNS, {
+    const { sourceColumns, targetColumn } = await api(queries.GET_PROJECT_COLUMNS, {
       sourceColumnIds,
       targetColumnId
     });
 
+    // paginate to gather all cards if needed
+    await paginateColumnCards(api, [...sourceColumns, targetColumn]);
+
     // apply user supplied filters to cards from the source column and mirror the
     // target column based on the remaining filters
-    const { sourceColumns, targetColumn } = response;
     const sourceCards = sourceColumns.flatMap(column => {
       return applyFilters(column.cards.nodes, [...Object.values(utils.filters)]);
     });

--- a/test/fixtures/get-project-columns.json
+++ b/test/fixtures/get-project-columns.json
@@ -8,7 +8,11 @@
         "name": "source project"
       },
       "cards": {
-        "nodes": []
+        "nodes": [],
+        "pageInfo": {
+          "hasNextPage": false,
+          "endCursor": null
+        }
       }
     }
   ],
@@ -20,7 +24,11 @@
       "name": "target project"
     },
     "cards": {
-      "nodes": []
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
     }
   }
 }

--- a/test/fixtures/get-single-project-column.json
+++ b/test/fixtures/get-single-project-column.json
@@ -1,0 +1,17 @@
+{
+  "column": {
+    "id": 1,
+    "name": "source column",
+    "url": "https://example.com/projects/1/columns/1",
+    "project": {
+      "name": "source project"
+    },
+    "cards": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
closes https://github.com/jonabc/linked-project-columns/issues/22

Adds pagination over the source and target column cards so that nothing is missed.  This can be important for columns that have a large number of cards, or if the target column contains cards from a large number of sources.

The code has been in use in a private project since August but once it was working I forgot to open a pull request 😞 