### PR TITLE
Check the return value when adding a card via the API

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6223,10 +6223,14 @@ async function ensureCardAtIndex(column, toIndex, findCardFunc, newCardFunc) {
   if (!card) {
     // add card to remote project column cards
     card = await api.addCardToColumn(column, newCardFunc());
-    currentIndex = 0;
 
-    // add the card to the local column cards
-    column.cards.nodes.splice(0, 0, card);
+    // add card to local project column cards if API was successful
+    if (card) {
+      currentIndex = 0;
+
+      // add the card to the local column cards
+      column.cards.nodes.splice(0, 0, card);
+    }
   }
 
   if (card && currentIndex !== toIndex) {

--- a/src/linked-project-columns.js
+++ b/src/linked-project-columns.js
@@ -26,10 +26,14 @@ async function ensureCardAtIndex(column, toIndex, findCardFunc, newCardFunc) {
   if (!card) {
     // add card to remote project column cards
     card = await api.addCardToColumn(column, newCardFunc());
-    currentIndex = 0;
 
-    // add the card to the local column cards
-    column.cards.nodes.splice(0, 0, card);
+    // add card to local project column cards if API was successful
+    if (card) {
+      currentIndex = 0;
+
+      // add the card to the local column cards
+      column.cards.nodes.splice(0, 0, card);
+    }
   }
 
   if (card && currentIndex !== toIndex) {

--- a/test/linked-project-columns.test.js
+++ b/test/linked-project-columns.test.js
@@ -207,6 +207,20 @@ describe('linked-project-columns', () => {
     expect(api.moveCardToIndex.getCall(0).args).toEqual([targetColumn, 0, 1]);
   });
 
+  it('does not add a card to the local target column when the remote call fails', async () => {
+    sourceColumns[0].cards.nodes.push({ id: 1, note: '1' });
+    // when the remote call fails, addCardToColumn returns null.  overwrite
+    // the default method stub to return null.
+    api.addCardToColumn.returns(null);
+
+    await run();
+    expect(targetColumn.cards.nodes).toEqual([]);
+
+    expect(api.addCardToColumn.callCount).toEqual(1);
+    expect(api.addCardToColumn.getCall(0).args).toEqual([targetColumn, { id: 1, note: '1' }]);
+    expect(api.moveCardToIndex.callCount).toEqual(0);
+  });
+
   it('moves cards on the target to match the source', async () => {
     sourceColumns[0].cards.nodes.push({ id: 1, note: '1' }, { id: 2, note: '2' });
     targetColumn.cards.nodes.push({ id: 202, note: '2' }, { id: 201, note: '1' });


### PR DESCRIPTION
Fixes an exception that can occur when `addCardToColumn` returns null after receiving an error response from the GitHub API.  Without the check, the action would add a null value into the `column.cards.nodes` array which could then cause any number of issues down the line in places that don't check that items in the array are non-null.

Given that the array is expected to contain non-null values, gracefully handling null values can lead to unexpected behavior that doesn't get noticed.  For now, I'm going to keep the code 💥  on null values until there's enough reason to properly handle null values in all places.

/cc @veganpolice